### PR TITLE
Better error display

### DIFF
--- a/src/components/SwapButton.js
+++ b/src/components/SwapButton.js
@@ -27,6 +27,15 @@ const useStyles = makeStyles((theme) => ({
         boxShadow: theme.shadows[5],
         padding: theme.spacing(2, 4, 3),
     },
+    buttonContainer: {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+    },
+    errorMessage: {
+        color: 'red',
+    }
+
 }));
 
 const Fade = React.forwardRef(function Fade(props, ref) {
@@ -89,7 +98,7 @@ const LoadingIcon = withStyles((theme) => ({
     }
 }))(CachedIcon);
 
-const renderButton = (swapState, approveSwap, swap) => {
+const renderButton = (swapState, approveSwap, swap, setError) => {
     switch (swapState) {
         case 'amountIsZero':
             return <ColourButton
@@ -99,7 +108,7 @@ const renderButton = (swapState, approveSwap, swap) => {
                 size="large">Enter an amount</ColourButton>;
         case 'initial':
             return <ColourButton
-                onClick={() => approveSwap()}
+                onClick={() => { approveSwap(); setError(null); }}
                 variant="contained"
                 color="secondary"
                 size="large"
@@ -115,7 +124,7 @@ const renderButton = (swapState, approveSwap, swap) => {
                 variant="contained"
                 color="secondary"
                 size="large"
-                onClick={() => swap()}
+                onClick={() => { swap(); setError(null); }}
                 startIcon={<SwapVertIcon />}>Swap for Ditto</ColourButton>;
         case 'swapLoading':
             return <ColourButton
@@ -129,8 +138,6 @@ const renderButton = (swapState, approveSwap, swap) => {
                 color="secondary"
                 size="large"
                 startIcon={<CheckIcon />}>Swap Complete</ColourButton>;
-        case 'error':
-            return <p>Error occured</p>;
         default:
             return null;
     }
@@ -153,10 +160,10 @@ export default function SwapButton(props) {
         if (props.swapState === 'swapComplete') handleOpen();
     }, [props.swapState]);
 
-
     return (
-        <div>
-            {renderButton(props.swapState, props.approveSwap, props.swap)}
+        <div className={classes.buttonContainer}>
+            {renderButton(props.swapState, props.approveSwap, props.swap, props.setError)}
+            {props.error && <p className={classes.errorMessage}>{props.error}</p>}
             {/* {props.swapState === 'initial' &&
                 <Tooltip title="Approve input tokens for swapping. Will only send an Ethereum transaction if prior approval is insufficient." aria-label="Approve input tokens for swapping. Will only send an Ethereum transaction if prior approval is insufficient." placement="top" interactive>
                     <InfoIcon color="secondary" style={{ fontSize: 25, paddingLeft: 10 }} />

--- a/src/pages/App.js
+++ b/src/pages/App.js
@@ -86,6 +86,7 @@ export default function App() {
   const [totalDittoRemaining, setTotalDittoRemaining] = React.useState();
   const [dittoRemainingForUser, setDittoRemainingForUser] = React.useState();
   const [swapState, setSwapState] = React.useState('amountIsZero');
+  const [error, setError] = React.useState(null);
   const [inputTokenAmount, setInputTokenAmount] = React.useState(0);
   const [usdDittoRate, setUsdDittoRate] = React.useState(0);
   const [approvedAllowanceAmount, setApprovedAllowanceAmount] = React.useState(0);
@@ -149,6 +150,7 @@ export default function App() {
   const handleTokenChange = (event) => {
     setSelectedToken(event.target.value);
     calculateOutputAmount(ethers.utils.formatUnits(inputTokenAmount, selectedToken.decimals), event.target.value);
+    setError(null);
   };
 
   const calculateOutputAmount = async (inputAmount, token) => {
@@ -157,9 +159,11 @@ export default function App() {
       const output = await swapContract.getDittoOutputAmount(convertedInputAmount, token.address);
       setDittoOutputAmount(ethers.utils.formatUnits(output, 9));
       setInputTokenAmount(convertedInputAmount);
+      setError(null);
     } else {
       setDittoOutputAmount(0);
       setInputTokenAmount(0);
+      setError(null);
     }
   };
 
@@ -180,8 +184,9 @@ export default function App() {
         } 
         setSwapState('swapApproved');
       } catch (error) {
-        console.log(error)
-        setSwapState('error');
+        console.log(error);
+        setError('Unable to complete transaction, please try again. :)');
+
       }
     }
   };
@@ -193,8 +198,8 @@ export default function App() {
       await swapTx.wait();
       setSwapState('swapComplete');
     } catch (error) {
-      console.log(error)
-      setSwapState('error');
+      console.log(error);
+      setError('Unable to complete transaction, please try again. :)');
     }
 
   };
@@ -234,7 +239,7 @@ export default function App() {
             <TokenOutputField loading={loading} dittoOutputAmount={dittoOutputAmount} />
           </div>
           <div className={classes.swapButton}>
-            <SwapButton swapState={swapState} approveSwap={approveSwap} swap={swap} dittoOutputAmount={dittoOutputAmount} />
+            <SwapButton swapState={swapState} approveSwap={approveSwap} swap={swap} dittoOutputAmount={dittoOutputAmount} error={error} setError={setError} />
           </div>
         </form>
         <div className={classes.dittoLeft}>


### PR DESCRIPTION
Resolves #12 . Show a short error message in case the transaction fails to prompt the user to try again. Will work out more accurate reasons later as currently complex to get the reason from chain.

Preview (**connected to mainnet contract**): https://swap-ui-git-clearer-error-state-bryanmutai.vercel.app/